### PR TITLE
Don't rename files if already correct

### DIFF
--- a/dist/rename.py
+++ b/dist/rename.py
@@ -158,8 +158,11 @@ def main():
         nfo_data = nfo_data_lookup.get((episode.season, episode.number))
         if nfo_data is None:
             continue
+
         episode.title = nfo_data.title
         new_episode_name = episode.get_file_name()
+        if Path(filepath).name == new_episode_name:
+            continue
 
         if dry_run:
             print('DRYRUN: "{}" -> "{}"'.format(Path(filepath).name, new_episode_name))


### PR DESCRIPTION
## Describe your changes
Small UX improvement. Means that you can actually see in stdout when for example you add a new file and run the rename script, only that one file being renamed - instead of every file being renamed again, cluttering the stdout.

## Checklist for submitting new .nfo files
n/a