### PR TITLE
Fixed S19E21 nfo being a duplicate of S19E22

### DIFF
--- a/One Pace/Season 19/One Pace - S19E21 - Rob Lucci.nfo
+++ b/One Pace/Season 19/One Pace - S19E21 - Rob Lucci.nfo
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--created on 2023-09-12 12:19:01 - tinyMediaManager 4.3.13-->
 <episodedetails>
-  <title>The Legend of the Mermaid</title>
+  <title>Rob Lucci</title>
   <originaltitle/>
   <showtitle>One Pace</showtitle>
   <season>19</season>
@@ -11,15 +11,15 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Lucci corners Luffy, weakened by his new ability’s aftereffects. Back on the bridge, Spandam makes an attempt on Robin's life, so Franky jumps into action. Meanwhile, the rest of the gang is about to drown in the flooded passageway.
+  <plot>With time running out, Luffy activates another special ability. The vice admirals of the buster call are shocked to see Luffy taking on Rob Lucci and recall how the CP9 enforcer, even in his youth, held strongly to a dark sense of justice.
 
-Manga Chapter(s): 423-424
+Manga Chapter(s): 421-422
 
-Anime Episode(s): 306-307</plot>
+Anime Episode(s): 304-305</plot>
   <runtime>0</runtime>
   <mpaa/>
-  <premiered>2020-06-15</premiered>
-  <aired>2020-06-15</aired>
+  <premiered>2020-06-06</premiered>
+  <aired>2020-06-06</aired>
   <watched>false</watched>
   <playcount>0</playcount>
   <trailer/>
@@ -48,6 +48,6 @@ Anime Episode(s): 306-307</plot>
   </fileinfo>
   <!--tinyMediaManager meta data-->
   <source>UNKNOWN</source>
-  <original_filename>One.Piece.E304-E305.1080p.mkv</original_filename>
+  <original_filename>[One Pace][421-422] Enies Lobby 21 [1080p][13D874FD].mkv</original_filename>
   <user_note/>
 </episodedetails>


### PR DESCRIPTION
Episodes S19E21 and S19E22 nfo files are duplicates. E21 should reflect the Rob Lucci episode information. Renamed and edited nfo to fix.

![image](https://github.com/SpykerNZ/one-pace-for-plex/assets/132759/9cb3e6e1-edd4-4720-90f5-26e4b5ab46cf)

## Checklist for submitting new .nfo files
- [X] I have validated that the new .nfo file works correctly in Plex