### PR TITLE
Update Reverse Mountain nfo's for rerelease

### DIFF
--- a/One Pace/Season 9/One Pace - S09E01 - Reverse Mountain.nfo
+++ b/One Pace/Season 9/One Pace - S09E01 - Reverse Mountain.nfo
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!--created on 2023-08-25 10:22:10 - tinyMediaManager 4.3.13-->
+<!--created on 2024-01-13 21:25:26 - tinyMediaManager 4.3.14-->
 <episodedetails>
   <title>Reverse Mountain</title>
   <originaltitle/>
@@ -11,15 +11,15 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Following a near disaster in the Calm Belt, the Straw Hats take a wild ride up and down a mountain… and are promptly swallowed by a giant whale!&#13;
-&#13;
-Manga Chapter(s): 101-103&#13;
-&#13;
-Anime Episode(s): 55, 61-62</plot>
+  <plot>Following a near disaster in the Calm Belt, the Straw Hats take a wild ride up and down a mountain… and are promptly swallowed by a giant whale!
+
+Manga Chapter(s): 101-102
+
+Anime Episode(s): 54-55, 61-62</plot>
   <runtime>0</runtime>
   <mpaa/>
-  <premiered>2017-12-01</premiered>
-  <aired>2017-12-01</aired>
+  <premiered>2024-01-05</premiered>
+  <aired>2024-01-05</aired>
   <watched>false</watched>
   <playcount>0</playcount>
   <trailer/>
@@ -31,9 +31,9 @@ Anime Episode(s): 55, 61-62</plot>
       <video>
         <codec>HEVC</codec>
         <aspect>1.33</aspect>
-        <width>640</width>
-        <height>480</height>
-        <durationinseconds>1912</durationinseconds>
+        <width>1440</width>
+        <height>1080</height>
+        <durationinseconds>1226</durationinseconds>
         <stereomode/>
       </video>
       <audio>
@@ -42,17 +42,26 @@ Anime Episode(s): 55, 61-62</plot>
         <channels>2</channels>
       </audio>
       <audio>
-        <codec>MP3</codec>
+        <codec>AAC</codec>
         <language>eng</language>
         <channels>2</channels>
       </audio>
       <subtitle>
         <language>eng</language>
       </subtitle>
+      <subtitle>
+        <language>eng</language>
+      </subtitle>
+      <subtitle>
+        <language>fra</language>
+      </subtitle>
+      <subtitle>
+        <language>spa</language>
+      </subtitle>
     </streamdetails>
   </fileinfo>
   <!--tinyMediaManager meta data-->
   <source>UNKNOWN</source>
-  <original_filename>One Pace - S08E01 - Reverse Mountain.mkv</original_filename>
+  <original_filename>One Pace - S09E01 - Reverse Mountain.mkv</original_filename>
   <user_note/>
 </episodedetails>

--- a/One Pace/Season 9/One Pace - S09E02 - Cape Promise.nfo
+++ b/One Pace/Season 9/One Pace - S09E02 - Cape Promise.nfo
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!--created on 2023-08-25 10:22:10 - tinyMediaManager 4.3.13-->
+<!--created on 2024-01-13 21:25:44 - tinyMediaManager 4.3.14-->
 <episodedetails>
   <title>Cape Promise</title>
   <originaltitle/>
@@ -11,15 +11,15 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>After learning of Laboon the whale's plight, Luffy comes up with a solution befitting his style. As thanks, Crocus reveals that navigating the Grand Line will not be as simple as following a compass or relying on currents and wind.&#13;
-&#13;
-Manga Chapter(s): 104-105&#13;
-&#13;
-Anime Episode(s): 63</plot>
+  <plot>After learning of Laboon the whale's plight, Luffy comes up with a solution befitting his style. As thanks, Crocus reveals that navigating the Grand Line will not be as simple as following a compass or relying on currents and wind.
+
+Manga Chapter(s): 103-105
+
+Anime Episode(s): 62-63</plot>
   <runtime>0</runtime>
   <mpaa/>
-  <premiered>2017-12-01</premiered>
-  <aired>2017-12-01</aired>
+  <premiered>2024-01-05</premiered>
+  <aired>2024-01-05</aired>
   <watched>false</watched>
   <playcount>0</playcount>
   <trailer/>
@@ -31,9 +31,9 @@ Anime Episode(s): 63</plot>
       <video>
         <codec>HEVC</codec>
         <aspect>1.33</aspect>
-        <width>640</width>
-        <height>480</height>
-        <durationinseconds>1071</durationinseconds>
+        <width>1440</width>
+        <height>1080</height>
+        <durationinseconds>1988</durationinseconds>
         <stereomode/>
       </video>
       <audio>
@@ -42,17 +42,26 @@ Anime Episode(s): 63</plot>
         <channels>2</channels>
       </audio>
       <audio>
-        <codec>MP3</codec>
+        <codec>AAC</codec>
         <language>eng</language>
         <channels>2</channels>
       </audio>
       <subtitle>
         <language>eng</language>
       </subtitle>
+      <subtitle>
+        <language>eng</language>
+      </subtitle>
+      <subtitle>
+        <language>fra</language>
+      </subtitle>
+      <subtitle>
+        <language>spa</language>
+      </subtitle>
     </streamdetails>
   </fileinfo>
   <!--tinyMediaManager meta data-->
   <source>UNKNOWN</source>
-  <original_filename>One Pace - S08E02 - Cape Promise.mkv</original_filename>
+  <original_filename>One Pace - S09E02 - Cape Promise.mkv</original_filename>
   <user_note/>
 </episodedetails>


### PR DESCRIPTION
## Describe your changes

Updates the Reverse Mountain nfo's due to recent re-release of these episodes

<img width="1049" alt="Screenshot 2024-01-13 at 21 35 28" src="https://github.com/SpykerNZ/one-pace-for-plex/assets/57002528/cbc27bd2-2efc-41e1-9033-61597aa6e6b1">

<img width="1076" alt="Screenshot 2024-01-13 at 21 35 44" src="https://github.com/SpykerNZ/one-pace-for-plex/assets/57002528/7e39902f-2213-4c05-b5ec-4bc0d7c0f859">

## Checklist for submitting new .nfo files
- [x] I have removed the old .nfo files that are being replaced
- [x] I have validated that the new .nfo file works correctly in Plex
- [x] I have updated the README, fixing the list of current missing episodes
- [x] I have modified exceptions.json, removing any exceptions no longer required