### PR TITLE
Add Egghead 02

### DIFF
--- a/One Pace/Season 35/One Pace - S35E02 - The Matter Involving Captain Koby.nfo
+++ b/One Pace/Season 35/One Pace - S35E02 - The Matter Involving Captain Koby.nfo
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--created on 2024-01-19 23:00:50 - tinyMediaManager 4.3.14-->
+<episodedetails>
+  <title>The Matter Involving Captain Koby</title>
+  <originaltitle/>
+  <showtitle>One Pace</showtitle>
+  <season>35</season>
+  <episode>2</episode>
+  <displayseason>-1</displayseason>
+  <displayepisode>-1</displayepisode>
+  <id/>
+  <ratings/>
+  <userrating>0.0</userrating>
+  <plot>The three-way struggle between the Marines, the Blackbeard Pirates, and the Kuja Pirates comes to an end when an unexpected figure shows up. On the Sunny, the Straw Hats talk about the recent incidents around the world and Luffy’s words surprise everyone.
+
+Manga Chapter(s): 1059-1060
+
+Anime Episode(s): 1087-1088</plot>
+  <runtime>0</runtime>
+  <mpaa/>
+  <premiered>2024-01-19</premiered>
+  <aired>2024-01-19</aired>
+  <watched>false</watched>
+  <playcount>0</playcount>
+  <trailer/>
+  <dateadded>2024-01-19 22:59:31</dateadded>
+  <epbookmark/>
+  <code/>
+  <fileinfo>
+    <streamdetails>
+      <video>
+        <codec>HEVC</codec>
+        <aspect>1.78</aspect>
+        <width>1920</width>
+        <height>1080</height>
+        <durationinseconds>1438</durationinseconds>
+        <stereomode/>
+      </video>
+      <audio>
+        <codec>AAC</codec>
+        <language>jpn</language>
+        <channels>2</channels>
+      </audio>
+      <subtitle>
+        <language>eng</language>
+      </subtitle>
+      <subtitle>
+        <language>fra</language>
+      </subtitle>
+    </streamdetails>
+  </fileinfo>
+  <!--tinyMediaManager meta data-->
+  <source>UNKNOWN</source>
+  <original_filename>[One Pace][1059-1060] Egghead 02 [1080p][01B6EE9A].mkv</original_filename>
+  <user_note/>
+</episodedetails>

--- a/One Pace/tvshow.nfo
+++ b/One Pace/tvshow.nfo
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!--created on 2023-09-17 14:20:13 - tinyMediaManager 4.3.13-->
+<!--created on 2024-01-19 23:00:28 - tinyMediaManager 4.3.14-->
 <tvshow>
   <title>One Pace</title>
   <originaltitle/>
@@ -46,6 +46,7 @@
   <namedseason number="32">32. Whole Cake Island</namedseason>
   <namedseason number="33">33. Reverie</namedseason>
   <namedseason number="34">34. Wano</namedseason>
+  <namedseason number="35">35. Egghead</namedseason>
   <mpaa/>
   <certification/>
   <episodeguide>{}</episodeguide>


### PR DESCRIPTION
## Describe your changes

Adds Egghead 02 and updates tvshows.nfo with Season 35

<img width="1078" alt="Screenshot 2024-01-19 at 23 07 33" src="https://github.com/SpykerNZ/one-pace-for-plex/assets/57002528/f2e36028-9133-4a67-8ead-1cde42492054">


## Checklist for submitting new .nfo files
- [x] I have removed the old .nfo files that are being replaced
- [x] I have validated that the new .nfo file works correctly in Plex
- [x] I have updated the README, fixing the list of current missing episodes
- [x] I have modified exceptions.json, removing any exceptions no longer required