### PR TITLE
Add .mp4 file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ One Pace/rename.py
 One Pace/seasons.json
 One Pace/exceptions.json
 One Pace/**/*.mkv
+One Pace/**/*.mp4
 One Pace/.DS_Store
 .DS_Store


### PR DESCRIPTION
## Describe your changes

Came across this when downloading some episodes from Telegram, which were .mp4 files and not the .mkv files that this script supported.

This change fixes that and allows both .mkv and .mp4 file extensions to work and be renamed correctly.

<img width="1206" alt="Screenshot 2024-01-24 at 01 20 22" src="https://github.com/SpykerNZ/one-pace-for-plex/assets/57002528/c2104b6d-5b80-49ea-933b-1849aa8b723f">
