### PR TITLE
CI: Automate pyinstaller builds for Windows

### DIFF
--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -39,5 +39,5 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Update rename.exe"
+          commit_message: "Update rename.exe (CI-${{ github.run_id }})"
           file_pattern: dist/rename.exe

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -19,12 +19,12 @@ jobs:
           python-version: 3.11
 
       - run: pip install pyinstaller
-      - run: pyinstaller dist/rename.py
+      - run: pyinstaller --onefile dist/rename.py
 
       - uses: actions/upload-artifact@v3
         with:
           name: rename.exe
-          path: dist/rename/rename.exe
+          path: dist/rename.exe
 
   commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - dist/rename.py
 
 jobs:
   build:

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -1,0 +1,25 @@
+name: pyinstaller-windows
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - run: pip install pyinstaller
+      - run: pyinstaller dist/rename.py
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rename.exe
+          path: dist/rename/rename.exe

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
       - run: pip install pyinstaller
       - run: pyinstaller --onefile dist/rename.py
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: rename.exe
           path: dist/rename.exe
@@ -31,8 +31,8 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: rename.exe
           path: dist

--- a/.github/workflows/pyinstaller-windows.yml
+++ b/.github/workflows/pyinstaller-windows.yml
@@ -23,3 +23,19 @@ jobs:
         with:
           name: rename.exe
           path: dist/rename/rename.exe
+
+  commit:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: rename.exe
+          path: dist
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update rename.exe"
+          file_pattern: dist/rename.exe


### PR DESCRIPTION
## Describe your changes

Sets up a GitHub actions workflow to automatically build `rename.exe` whenever `rename.py` changes.  
This test branch shows it working - https://github.com/cawnj/one-pace-for-plex/tree/pyinstaller-gh-actions-test

Using the command `pyinstaller --onefile dist/rename.py`, not sure if there's any other options you use @SpykerNZ but it seems to output a working exe at least.

Lots of small commits here so if it's good to go (and something we actually want integrated in the first place!), a squash and merge is best 🙏 