### PR TITLE
Egghead 5 and 6

### DIFF
--- a/One Pace/Season 36/One Pace - S36E05 - The Six Vegapunks.nfo
+++ b/One Pace/Season 36/One Pace - S36E05 - The Six Vegapunks.nfo
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<!--created on 2024-04-20 01:22:38 - tinyMediaManager 5.0.3-->
+<episodedetails>
+  <title>The Six Vegapunks</title>
+  <originaltitle/>
+  <showtitle>One Pace</showtitle>
+  <season>36</season>
+  <episode>5</episode>
+  <displayseason>-1</displayseason>
+  <displayepisode>-1</displayepisode>
+  <id/>
+  <ratings/>
+  <userrating>0.0</userrating>
+  <plot>Lilith takes the Sunny and its remaining crew to the laboratory in the clouds, where a new threat lurking within its corridors attacks unexpectedly. As the battle ensues, Vegapunk's satellites look on with excitement.
+
+Manga Chapter(s): 1064-1065
+
+Anime Episode(s): 1093-1095</plot>
+  <runtime>0</runtime>
+  <mpaa/>
+  <premiered>2024-03-22</premiered>
+  <aired>2024-03-22</aired>
+  <watched>false</watched>
+  <playcount>0</playcount>
+  <dateadded>2024-04-20 01:22:36</dateadded>
+  <fileinfo>
+    <streamdetails>
+      <video>
+        <codec>HEVC</codec>
+        <aspect>1.78</aspect>
+        <width>1920</width>
+        <height>1080</height>
+        <durationinseconds>1954</durationinseconds>
+        <stereomode/>
+      </video>
+      <audio>
+        <codec>AAC</codec>
+        <language>jpn</language>
+        <channels>2</channels>
+      </audio>
+      <subtitle>
+        <language>eng</language>
+      </subtitle>
+      <subtitle>
+        <language>fra</language>
+      </subtitle>
+    </streamdetails>
+  </fileinfo>
+  <!--tinyMediaManager meta data-->
+  <source>UNKNOWN</source>
+  <original_filename>[One Pace][1064-1065] Egghead 05 [1080p][E80E4B80].mkv</original_filename>
+  </episodedetails>

--- a/One Pace/Season 36/One Pace - S36E06 - The Will of Ohara.nfo
+++ b/One Pace/Season 36/One Pace - S36E06 - The Will of Ohara.nfo
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<!--created on 2024-04-20 01:17:17 - tinyMediaManager 5.0.3-->
+<episodedetails>
+  <title>The Will of Ohara</title>
+  <originaltitle/>
+  <showtitle>One Pace</showtitle>
+  <season>36</season>
+  <episode>6</episode>
+  <displayseason>-1</displayseason>
+  <displayepisode>-1</displayepisode>
+  <id/>
+  <ratings/>
+  <userrating>0.0</userrating>
+  <plot>Vegapunk Shaka shares his theory about an ancient kingdom and the Void Century. He also reminisces about the foundation of Dragon's Revolutionary Army. Meanwhile, Luffy and Chopper try to activate the giant robot when something surprising happens.
+
+Manga Chapter(s): 1066
+
+Anime Episode(s): 1096-1097</plot>
+  <runtime>0</runtime>
+  <mpaa/>
+  <premiered>2024-04-19</premiered>
+  <aired>2024-04-19</aired>
+  <watched>false</watched>
+  <playcount>0</playcount>
+  <dateadded>2024-04-20 01:16:00</dateadded>
+  <fileinfo>
+    <streamdetails>
+      <video>
+        <codec>HEVC</codec>
+        <aspect>1.78</aspect>
+        <width>1920</width>
+        <height>1080</height>
+        <durationinseconds>1185</durationinseconds>
+        <stereomode/>
+      </video>
+      <audio>
+        <codec>AAC</codec>
+        <language>jpn</language>
+        <channels>2</channels>
+      </audio>
+      <subtitle>
+        <language>eng</language>
+      </subtitle>
+      <subtitle>
+        <language>fra</language>
+      </subtitle>
+    </streamdetails>
+  </fileinfo>
+  <!--tinyMediaManager meta data-->
+  <source>UNKNOWN</source>
+  <original_filename>[One Pace][1066] Egghead 06 [1080p][C9D76388].mkv</original_filename>
+  </episodedetails>


### PR DESCRIPTION
## Describe your changes

Adds Egghead 6 and re-adds 5, since I think we lost it during the big season shift done for "if you could go anywhere"

## Checklist for submitting new .nfo files
- [x] I have removed the old .nfo files that are being replaced
- [x] I have validated that the new .nfo file works correctly in Plex
- [x] I have added a screenshot to my pull request, showing the episode in Plex with the correct metadata
- [x] I have updated the README, fixing the list of current missing episodes
- [x] I have modified exceptions.json, removing any exceptions no longer required

![image](https://github.com/SpykerNZ/one-pace-for-plex/assets/33820904/b0e2922b-2f10-4a4b-aa69-239982dbf408)


![image](https://github.com/SpykerNZ/one-pace-for-plex/assets/33820904/fe5383f3-baaa-4890-8d8c-5287d0682a5e)
