### PR TITLE
Removed carriage returns from NFOs

### DIFF
--- a/One Pace/Season 10/One Pace - S10E01 - The Town of Celebration.nfo
+++ b/One Pace/Season 10/One Pace - S10E01 - The Town of Celebration.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>As the Straw Hat Pirates travel from Reverse Mountain to Whisky Peak, Nami adjusts to having to watch the log pose constantly. When they arrive at their destination, the townspeople greet them warmly, despite the sight of their Jolly Roger.&#13;
-&#13;
-Manga Chapter(s): 106-109&#13;
-&#13;
+  <plot>As the Straw Hat Pirates travel from Reverse Mountain to Whisky Peak, Nami adjusts to having to watch the log pose constantly. When they arrive at their destination, the townspeople greet them warmly, despite the sight of their Jolly Roger.
+
+Manga Chapter(s): 106-109
+
 Anime Episode(s): 64-65</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 10/One Pace - S10E02 - The Secret Criminal Organization.nfo
+++ b/One Pace/Season 10/One Pace - S10E02 - The Secret Criminal Organization.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>As Mr. 5 and Miss Valentine chase after the fleeing princess Vivi, Igaram begs Zoro to save her. But just when Zoro is about to take on Vivi's assailants, an enraged Luffy confronts him under a massive misunderstanding of the swordsman's latest actions.&#13;
-&#13;
-Manga Chapter(s): 110-114&#13;
-&#13;
+  <plot>As Mr. 5 and Miss Valentine chase after the fleeing princess Vivi, Igaram begs Zoro to save her. But just when Zoro is about to take on Vivi's assailants, an enraged Luffy confronts him under a massive misunderstanding of the swordsman's latest actions.
+
+Manga Chapter(s): 110-114
+
 Anime Episode(s): 65-67</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 11/One Pace - S11E01 - The Trials of Koby Meppo.nfo
+++ b/One Pace/Season 11/One Pace - S11E01 - The Trials of Koby Meppo.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Koby and Helmeppo are new cabin boys for the marines, but they become unwillingly involved in an escape attempt by Morgan. Their bravery will either earn them the respect of their superiors—as well as Vice Admiral Garp—or it will spell their doom.&#13;
-&#13;
-Manga Chapter(s): 83-119 cover stories&#13;
-&#13;
+  <plot>Koby and Helmeppo are new cabin boys for the marines, but they become unwillingly involved in an escape attempt by Morgan. Their bravery will either earn them the respect of their superiors—as well as Vice Admiral Garp—or it will spell their doom.
+
+Manga Chapter(s): 83-119 cover stories
+
 Anime Episode(s): 68-69</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 12/One Pace - S12E01 - Adventure on Little Garden.nfo
+++ b/One Pace/Season 12/One Pace - S12E01 - Adventure on Little Garden.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>The Straw Hats arrive at their destination and discover that the island is home to enormous creatures... and people. Meanwhile, the Baroque Works agents Mr. 3 and his partner Miss Golden Week receive new orders.&#13;
-&#13;
-Manga Chapter(s): 115-117&#13;
-&#13;
+  <plot>The Straw Hats arrive at their destination and discover that the island is home to enormous creatures... and people. Meanwhile, the Baroque Works agents Mr. 3 and his partner Miss Golden Week receive new orders.
+
+Manga Chapter(s): 115-117
+
 Anime Episode(s): 70-71</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 12/One Pace - S12E02 - Dorry and Brogy.nfo
+++ b/One Pace/Season 12/One Pace - S12E02 - Dorry and Brogy.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Usopp, immensely impressed with the giants of Elbaf, names Brogy his master. To commemorate their duel, the giants imbibe two barrels of booze from Nami, but, unbeknownst to anyone, a saboteur has tampered with one of them!&#13;
-&#13;
-Manga Chapter(s): 117-118&#13;
-&#13;
+  <plot>Usopp, immensely impressed with the giants of Elbaf, names Brogy his master. To commemorate their duel, the giants imbibe two barrels of booze from Nami, but, unbeknownst to anyone, a saboteur has tampered with one of them!
+
+Manga Chapter(s): 117-118
+
 Anime Episode(s): 71-72</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 12/One Pace - S12E04 - Luffy vs. Mr. 3.nfo
+++ b/One Pace/Season 12/One Pace - S12E04 - Luffy vs. Mr. 3.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Luffy, Usopp, and Karoo launch headlong into rescuing their friends, but Miss Golden Week runs a colorful interference. Mr. 3 is forced to take matters into his own conniving hands, and Usopp brainstorms how he will finally free his friends.&#13;
-&#13;
-Manga Chapter(s): 123-126&#13;
-&#13;
+  <plot>Luffy, Usopp, and Karoo launch headlong into rescuing their friends, but Miss Golden Week runs a colorful interference. Mr. 3 is forced to take matters into his own conniving hands, and Usopp brainstorms how he will finally free his friends.
+
+Manga Chapter(s): 123-126
+
 Anime Episode(s): 75-76</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 14/One Pace - S14E05 - I Love My Country.nfo
+++ b/One Pace/Season 14/One Pace - S14E05 - I Love My Country.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>At Rain Dinners, the Baroque Works officer agents are finally let on to Mr. 0's true identity. And just outside Yuba, Luffy confronts a stubborn Vivi to remind her who else is willing to stand with her.&#13;
-&#13;
-Manga Chapter(s): 164-166&#13;
-&#13;
+  <plot>At Rain Dinners, the Baroque Works officer agents are finally let on to Mr. 0's true identity. And just outside Yuba, Luffy confronts a stubborn Vivi to remind her who else is willing to stand with her.
+
+Manga Chapter(s): 164-166
+
 Anime Episode(s): 100, 103-104</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 14/One Pace - S14E06 - Rainbase, the City of Dreams.nfo
+++ b/One Pace/Season 14/One Pace - S14E06 - Rainbase, the City of Dreams.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Luffy's band reaches the city of Rainbase but run afoul of Smoker and Tashigi. As they defend themselves against both the Navy and Baroque Works' millions, Luffy's party storms Crocodile's Rain Dinners Casino.&#13;
-&#13;
-Manga Chapter(s): 166-168&#13;
-&#13;
+  <plot>Luffy's band reaches the city of Rainbase but run afoul of Smoker and Tashigi. As they defend themselves against both the Navy and Baroque Works' millions, Luffy's party storms Crocodile's Rain Dinners Casino.
+
+Manga Chapter(s): 166-168
+
 Anime Episode(s): 104-105</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 14/One Pace - S14E07 - It Begins.nfo
+++ b/One Pace/Season 14/One Pace - S14E07 - It Begins.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Luffy leads a daring—but foolish—raid on Crocodile’s casino. His poor planning lands him behind bars with Captain Smoker. But more importantly, these actions leave Vivi alone and unprotected.&#13;
-&#13;
-Manga Chapter(s): 169-170&#13;
-&#13;
+  <plot>Luffy leads a daring—but foolish—raid on Crocodile’s casino. His poor planning lands him behind bars with Captain Smoker. But more importantly, these actions leave Vivi alone and unprotected.
+
+Manga Chapter(s): 169-170
+
 Anime Episode(s): 106</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 7/One Pace - S07E01 - The Adventures of Buggy's Crew.nfo
+++ b/One Pace/Season 7/One Pace - S07E01 - The Adventures of Buggy's Crew.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Buggy, after being defeated by Luffy, Zoro, and Nami, begins his quest to regain his body parts and his crew, and then he will get his flashy revenge on Luffy.&#13;
-&#13;
-Manga Chapter(s): 35-75 cover stories&#13;
-&#13;
+  <plot>Buggy, after being defeated by Luffy, Zoro, and Nami, begins his quest to regain his body parts and his crew, and then he will get his flashy revenge on Luffy.
+
+Manga Chapter(s): 35-75 cover stories
+
 Anime Episode(s): 46-47</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 8/One Pace - S08E01 - The Town of Beginnings and Endings.nfo
+++ b/One Pace/Season 8/One Pace - S08E01 - The Town of Beginnings and Endings.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Touting a fresh bounty issued by Navy HQ, Luffy and co. make landfall at Loguetown, the place where Gold Roger was both born and executed. Being the last stop before the Grand Line, the crew stocks up on supplies and sightsees.&#13;
-&#13;
-Manga Chapter(s): 96-97&#13;
-&#13;
+  <plot>Touting a fresh bounty issued by Navy HQ, Luffy and co. make landfall at Loguetown, the place where Gold Roger was both born and executed. Being the last stop before the Grand Line, the crew stocks up on supplies and sightsees.
+
+Manga Chapter(s): 96-97
+
 Anime Episode(s): 45, 48-49</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 8/One Pace - S08E02 - Parallels.nfo
+++ b/One Pace/Season 8/One Pace - S08E02 - Parallels.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Usopp manages to anger the brat daughter of bounty hunter Daddy the Father and finds his own life at stake. When Daddy discovers that Usopp is the son of Red Hair Pirate Yasopp, the only man to beat him, he offers him a risky way out.&#13;
-&#13;
-Manga Chapter(s): 97&#13;
-&#13;
+  <plot>Usopp manages to anger the brat daughter of bounty hunter Daddy the Father and finds his own life at stake. When Daddy discovers that Usopp is the son of Red Hair Pirate Yasopp, the only man to beat him, he offers him a risky way out.
+
+Manga Chapter(s): 97
+
 Anime Episode(s): 48, 50-51</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Season 8/One Pace - S08E03 - The Legend Has Begun.nfo
+++ b/One Pace/Season 8/One Pace - S08E03 - The Legend Has Begun.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Luffy finally finds the execution platform, only to be caught in Buggy and Alvida's trap. Sanji and Zoro rush to stop Buggy from poetically executing Luffy where Roger died.&#13;
-&#13;
-Manga Chapter(s): 98-100&#13;
-&#13;
+  <plot>Luffy finally finds the execution platform, only to be caught in Buggy and Alvida's trap. Sanji and Zoro rush to stop Buggy from poetically executing Luffy where Roger died.
+
+Manga Chapter(s): 98-100
+
 Anime Episode(s): 52-53</plot>
   <runtime>0</runtime>
   <mpaa/>

--- a/One Pace/Specials/One Pace - S00E04 - Wapol's Omnivorous Hurrah.nfo
+++ b/One Pace/Specials/One Pace - S00E04 - Wapol's Omnivorous Hurrah.nfo
@@ -11,10 +11,10 @@
   <id/>
   <ratings/>
   <userrating>0.0</userrating>
-  <plot>Description unavailable.&#13;
-&#13;
-Manga Chapter(s): 236-262 Covers&#13;
-&#13;
+  <plot>Description unavailable.
+
+Manga Chapter(s): 236-262 Covers
+
 Anime Episode(s): 778</plot>
   <runtime>0</runtime>
   <mpaa/>


### PR DESCRIPTION
## Describe your changes
I removed all carriage return HTML codes (`&#13;`) from all NFO files. I don't have "One Pace for Plex" set up right now, so I couldn't test it, but this modification shouldn't have any impact on Plex (it's just deleting blank characters from the NFOs)

## Checklist for submitting new .nfo files
- [ ] I have removed the old .nfo files that are being replaced
- [ ] I have validated that the new .nfo file works correctly in Plex
- [ ] I have added a screenshot to my pull request, showing the episode in Plex with the correct metadata
- [ ] I have updated the README, fixing the list of current missing episodes
- [ ] I have modified exceptions.json, removing any exceptions no longer required
