### PR TITLE
Add the alternate S16 finale

### DIFF
--- a/One Pace/Season 16/One Pace - S16E25 - Finale (Alternate - G-8).nfo
+++ b/One Pace/Season 16/One Pace - S16E25 - Finale (Alternate - G-8).nfo
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<episodedetails>
+  <title>Finale</title>
+  <showtitle>One Pace</showtitle>
+  <season>16</season>
+  <episode>25</episode>
+  <plot>An alternate version of Skypiea 25 that leads into the G-8 filler arc
+  
+  Chapters: 302-303
+  Episodes: 195, 207</plot>
+  <premiered>2025-05-03</premiered>
+  <aired>2025-05-03</aired>
+</episodedetails>


### PR DESCRIPTION
## Describe your changes
Add the alternate ending. Like the extended editions, only one version of each episode should be used at a given time. 

Both NFO files can exist together, just not both video files.

## Checklist for submitting new .nfo files
- [x] I have removed the old .nfo files that are being replaced
- [x] I have validated that the new .nfo file works correctly in Plex
- [x] I have added a screenshot to my pull request, showing the episode in Plex with the correct metadata
- [x] I have updated the README, fixing the list of current missing episodes
- [x] I have modified exceptions.json, removing any exceptions no longer required


![image](https://github.com/user-attachments/assets/b285e294-1d09-4e02-8e02-0adca6b0f47f)
